### PR TITLE
(More) minor fixes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -24,54 +24,59 @@ googleAnalytics = ""
     weight = 2
 
 [[menu.main]]
+    name = "Register"
+    url  = "https://ecommerce.uoregon.edu/order_form/brt-cascadia-r-conference"
+    weight = 3
+
+[[menu.main]]
     name = "Venue"
     url  = "/venue/"
-    weight = 3
+    weight = 4
 
 [[menu.main]]
     name = "Agenda"
     url  = "/agenda/"
-    weight = 4
+    weight = 5
 	
 [[menu.main]]
     name = "Speakers"
     identifier = "speakers"
     url  = "#"
-    weight = 5
+    weight = 6
     
 [[menu.main]]
     name = "Keynote speakers"
     parent = "speakers"
     url  = "/speakers/keynote"
-    weight = 5.1
+    weight = 6.1
     
 [[menu.main]]
     name = "Workshop instructors"
     parent = "speakers"
     url  = "/speakers/workshop"
-    weight = 5.2
+    weight = 6.2
 
 [[menu.main]]
     name = "Policies"
     identifier = "policies"
     url  = "/policies/"
-    weight = 6
+    weight = 7
 
 [[menu.main]]
     name = "FAQ"
     identifier = "faq"
     url  = "/faq/"
-    weight = 7
+    weight = 8
 
 [[menu.main]]
     name = "Sponsors"
     url  = "/sponsors/"
-    weight = 8
+    weight = 9
 
 [[menu.main]]
     name = "Years"
     url  = "/years/"
-    weight = 9
+    weight = 10
 
 # Top bar social links menu
 

--- a/content/agenda/index.md
+++ b/content/agenda/index.md
@@ -126,7 +126,7 @@ border-color:black;
     For more details about this workshop, including the <a href="https://tidyml-cascadiarconf.netlify.com/prework/">prework</a> to complete before attending, please click the link below:<br>
     <a href="https://tidyml-cascadiarconf.netlify.com">https://tidyml-cascadiarconf.netlify.com</a>
     </td><td>TBD</td/></tr>
-<tr><td>12:15am-1:15pm</td><td><h4>Lunch</h4></td><td>TBD</td></tr>
+<tr><td>12:15pm-1:15pm</td><td><h4>Lunch</h4></td><td>TBD</td></tr>
 <tr><td>1:15pm-2:00pm</td>
 	<td><h4>Afternoon Keynote</h4>
 	<a class="agendaLink" href="/speakers/keynote/heather_nolis">Heather Nolis</a> and 
@@ -155,7 +155,7 @@ This workshop will discuss (a) modifications to your R Markdown document to chan
     See Part 1 info above for details.
     </td><td>TBD</td/></tr>
 <tr><td>4:15pm-4:30pm</td><td><h4>Break</h4></td><td>TBD</td></tr>
-<tr><td>4:30am-5:00pm</td><td><h4>Happy hour, lightning talks</h4></td><td>TBD</td></tr>
+<tr><td>4:30pm-5:30pm</td><td><h4>Happy hour, lightning talks</h4></td><td>TBD</td></tr>
 </table>
 
   <br><br><br><br>

--- a/data/features/talks.yaml
+++ b/data/features/talks.yaml
@@ -2,3 +2,4 @@ weight: 2
 name: "Keynotes"
 icon: "fas fa-bullhorn"
 description: "In addition to lightning talks, we will have two 45-minute keynotes from leaders in the field of data science and open source."
+url: "/speakers/keynote"

--- a/data/features/training.yaml
+++ b/data/features/training.yaml
@@ -2,3 +2,4 @@ weight: 3
 name: "Trainings"
 icon: "fab fa-r-project"
 description: "Beginner and advanced training sessions will be available- choose your level."
+url: "/speakers/workshop"


### PR DESCRIPTION
-corrected timeline typos in agenda
-created a separate navbar section `Registration` that links to the registration website
-linked the "keynote" and "training" icons (under `Home`) to respective speaker pages

Preview:
https://gracious-sammet-56c7d6.netlify.com/