### PR TITLE
Quick fixes for 2021 and publishing CFP

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -36,20 +36,20 @@ googleAnalytics = ""
 [[menu.main]]
     name = "Speakers"
     identifier = "speakers"
-    url  = "#"
+    url  = "/speakers/"
     weight = 5
     
-[[menu.main]]
-    name = "Keynote speakers"
-    parent = "speakers"
-    url  = "/speakers/keynote"
-    weight = 5.1
+#[[menu.main]]
+#    name = "Keynote speakers"
+#    parent = "speakers"
+#    url  = "/speakers/keynote"
+#    weight = 5.1
     
-[[menu.main]]
-    name = "Workshop instructors"
-    parent = "speakers"
-    url  = "/speakers/workshop"
-    weight = 5.2
+#[[menu.main]]
+#    name = "Workshop instructors"
+#    parent = "speakers"
+#    url  = "/speakers/workshop"
+#    weight = 5.2
 
 [[menu.main]]
     name = "Policies"
@@ -159,9 +159,9 @@ googleAnalytics = ""
     enable = true
     icon = "fas fa-bolt"
     title = "SUBMIT A PRESENTATION"
-    subtitle = "Call for regular 15 minute talk and 5 minute lightning talk submissions now open! <br>Proposals are due March 15th, 2021."
-    link_url = "https://forms.gle/y9VRggFfN7B2MfCz9"
-    link_text = "SUBMISSION PORTAL"
+    subtitle = "Submissions for both regular 15 minute presentations and 5 minute lightning talks are now open!<br>See our Call for Presentations for more information.<br>Proposals are due March 15th, 2021."
+    link_url = "/speakers/"
+    link_text = "CALL FOR PRESENTATIONS"
 
 [params.clients]
     enable = false

--- a/config.toml
+++ b/config.toml
@@ -98,7 +98,7 @@ googleAnalytics = ""
     viewMorePostLink = "/blog/"
     author = "Scott Chamberlain"
     defaultKeywords = ["r", "data science", "conference"]
-    defaultDescription = "Cascadia R Conference is an R conference serving the Pacific Northwest region (Oregon/Washington/BC)."
+    defaultDescription = "Cascadia R Conference is an R conference serving the Pacific Northwest region (Alaska/British Columbia/Washington/Oregon/California)."
 
     # Google Maps API key (if not set will default to not passing a key.)
     # #googleMapsApiKey = "AIzaSyCFhtWLJcE30xOAjcbSFi-0fnoVmQZPb1Y"
@@ -106,20 +106,20 @@ googleAnalytics = ""
     # Style options: default (light-blue), blue, green, marsala, pink, red, turquoise, violet
     style = "blue"
 
-    about_us = "<p>CascadiaRConf is a regional R conference for the Pacific Northwest - brought to you by <a href='https://pdxrlang.com/'>pdxrlang</a></p>"
+    about_us = "<p>Cascadia R Conference is a regional R conference for the Pacific Northwest</p>"
 
     # Format dates with Go's time formatting
     date_format = "January 2, 2006"
 
-    logo = "img/Cascadia_R_2020_logo_small.png"
-    logo_small = "img/Cascadia_R_2020_logo_small.png"
-    logo_sticker = "img/Cascadia_R_2020_logo.png"
-	  description = "CascadiaRConf is a regional R conference for the Pacific Northwest - For 2020, the conference will be held in Eugene, OR!"
-    latitude = "-12.043333"
-    longitude = "-77.028333"
+    logo = "img/logo2.png"
+    logo_small = "img/logo2.png"
+    logo_sticker = "img/sticker_new.png"
+	  description = "CascadiaRConf is a regional R conference for the Pacific Northwest - For 2021, the conference will be held virtually!"
+    #latitude = "-12.043333"
+    #longitude = "-77.028333"
     
-    default_sharing_image = "img/Cascadia_R_2020_logo.png"
-    twitterImage = "img/Cascadia_R_2020_logo.png"
+    default_sharing_image = "img/sticker_new.png"
+    twitterImage = "img/sticker_new.png"
 
 [Permalinks]
     blog = "/blog/:year/:month/:day/:filename/"
@@ -142,7 +142,7 @@ googleAnalytics = ""
     # For more informtion take a look at the README.
 
 [params.features]
-    enable = true
+    enable = false
     # All features are defined in their own files. You can find example items
     # at 'exampleSite/data/features'.
     # For more informtion take a look at the README.
@@ -158,13 +158,13 @@ googleAnalytics = ""
 [params.see_more]
     enable = true
     icon = "fas fa-bolt"
-    title = "SUBMIT A LIGHTNING TALK"
-    subtitle = "Call for 5-min lightning talk submissions now open! <br>Proposals are due April 15th, 2020."
-    link_url = "https://docs.google.com/forms/d/e/1FAIpQLSfJOSQzSEkfpsNJQeuTZJ-WxLOhty_tZ6eh9mI84uUhU-1R6Q/viewform"
+    title = "SUBMIT A PRESENTATION"
+    subtitle = "Call for regular 15 minute talk and 5 minute lightning talk submissions now open! <br>Proposals are due March 15th, 2021."
+    link_url = "https://forms.gle/y9VRggFfN7B2MfCz9"
     link_text = "SUBMISSION PORTAL"
 
 [params.clients]
-    enable = true
+    enable = false
     # All clients are defined in their own files. You can find example items
     # at 'exampleSite/data/clients'.
     # For more informtion take a look at the README.

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -4,7 +4,10 @@ title: "About"
 
 Cascadia R Conference is an R conference serving the Pacific Northwest region (Oregon/Washington/BC).
 
-The conference first started in 2017, and we're back in 2020 in Eugene, OR. See you there!
+The conference first started in 2017, 
+and while we had to cancel our plans to meet in 2020 in Eugene, OR,
+we're back with a virtual conference in 2021.
+See you there!
 
 We wanted to run this event as there are relatively few R conferences. In addition, 
 the <a href="https://www.meetup.com/portland-r-user-group/">Portland R User Group</a>

--- a/content/agenda/agenda-2020.html
+++ b/content/agenda/agenda-2020.html
@@ -62,7 +62,6 @@ border-color:black;
  -->
 <h1>Schedule</h1>
 
-<!-- 
 <ul>
 	<table class="speakers">
 		<col span=1 class="portraitContainer">
@@ -158,6 +157,5 @@ This workshop will discuss (a) modifications to your R Markdown document to chan
 <tr><td>4:15pm-4:30pm</td><td><h4>Break</h4></td><td>TBD</td></tr>
 <tr><td>4:30pm-5:30pm</td><td><h4>Happy hour, lightning talks</h4></td><td>TBD</td></tr>
 </table>
--->
 
   <br><br><br><br>

--- a/content/faq/index.md
+++ b/content/faq/index.md
@@ -11,17 +11,15 @@ YES! See the <a href="/policies">Policies</a> page.
 
 ## When will it be?
 
-May 31st, 2020
+June 4-5, 2021e
 
 ## Where will it be?
 
-Erb Memorial Union <br> 
-University of Oregon
-1395 University St <br>
-Eugene, OR 97403
+We're holding the 2021 conference virtually.
 
 See the <a href="/venue"> Venue</a> page.
 
+<!--
 ## Are there discounts for students?
 
 Yes! Student tickets are $30.
@@ -40,13 +38,6 @@ Register/get a ticket [here](https://ecommerce.uoregon.edu/order_form/brt-cascad
 ## Will you provide lunch?
 Unfortunately we are unable to provide lunch this year.
 
-## What about next year (2021)?
-We'll let you know at the end of the conference on May 31st
-
-## Will talks be recorded?
-
-TBD
-
 ## What about parking?
 Parking in most University of Oregon parking lots will be free for the day of the conference (given it's a Sunday). Please see the PDF map <a href = "https://business.uoregon.edu/sites/business1.uoregon.edu/files/media/campus-parking-map.pdf"> here </a> for a list of parking lots and their relation to the EMU. 
 
@@ -55,6 +46,14 @@ Metered parking is also generally free on Sunday, and the spots on University St
 ## Will there be a lactation room?
 
 TBD
+-->
+
+## Will talks be recorded?
+
+Most likely!
+
+## What about next year (2022)?
+We'll let you know at the end of 2021!
 
 <br><br>
 

--- a/content/faq/index.md
+++ b/content/faq/index.md
@@ -11,13 +11,14 @@ YES! See the <a href="/policies">Policies</a> page.
 
 ## When will it be?
 
-June 4-5, 2021e
+June 4-5, 2021
 
 ## Where will it be?
 
 We're holding the 2021 conference virtually.
 
-See the <a href="/venue"> Venue</a> page.
+See the <a href="/venue"> Venue</a> page for more information
+as the conference approaches.
 
 <!--
 ## Are there discounts for students?

--- a/content/policies.md
+++ b/content/policies.md
@@ -10,7 +10,7 @@ Contact numbers:
 
 ## Code of Conduct
 
-CascadiaConf is dedicated to providing a harassment-free conference experience for everyone regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organizers.
+Cascadia R Conference is dedicated to providing a harassment-free conference experience for everyone regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organizers.
 
 Harassment includes verbal comments that reinforce social structures of domination related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion; sexual images in public spaces; deliberate intimidation; stalking; following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact; and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
 

--- a/content/speakers/index.md
+++ b/content/speakers/index.md
@@ -1,0 +1,22 @@
+---
+title: "Speakers: Call for Presentations"
+---
+
+It is with great pleasure that we announce the Call for Presentations for the 2021 Cascadia R Conference to be held virtually on June 4-5, 2021.
+
+The goals of the conference are to showcase the interesting ways R is being used in the region, provide learning opportunities, and connect R programmers with one another. The presentations, therefore, are a platform for promoting these ideals. 
+
+The theme of the 2021 conference is “infectious ideas”.  This is purposefully broad to allow a diverse suite of talks.  Some examples of topics that would fit in this theme include:
+- Using R for collaborating and communicating with a diverse audience: using blogs/websites, reports, Shiny Dashboards, leaflet maps
+- Effective R packages and how you use them in your work: you don’t have to be the author of a package to share how you use it!
+- Making the R ecosystem more inclusive: sharing skills, building community
+- Using R in education: training in R, or using R to teach non-R concepts
+- Spreading R culture in your organization: infusing your colleagues with enthusiasm for R and a culture of sharing
+
+Applicants should note that presentations are being solicited to fill a 15-minute presentation window (15 minutes for talk, with 3 speakers sharing a 15 minute question and answer period to round out an hour-long session). 5 minute lightning talk applications are also being accepted. Student talks will receive special consideration. Our audience is of varying skill level, and from a wide range of organizations: non-profit, academic, government, and industry.  A representative volunteer will be provided the day of the conference to assist with timing, introductions, and facilitate interactions with the audience. Presenters are expected to comply with the <a href="/policies">Code of Conduct</a> of the conference. 
+
+Please note that Cascadia R Conference is a regional conference that focuses on R users from the Cascadia region (primarily Alaska, British Columbia, Washington, Oregon, and California). Submissions are welcome from those outside of the region, but priority may be given to submissions from Cascadia locations.
+
+To apply, fill out and submit the <a href="https://forms.gle/y9VRggFfN7B2MfCz9">Cascadia R Conference 2021 talk submission form</a>. Applicants must include an abstract limited to 500 words describing your presentation and how it aligns with the goals of the conference, as well as email contact information. 
+
+The Call for Presentations will open Feb 5, 2021 and will close March 15, 2021. Presenters will be notified by April 1, 2021. Upon notification, presenters are expected to confirm acceptance, provide high quality headshots, and a short biography that will be included on the Cascadia R Conference website. Prior to the conference, copies of final presentation are required to be made available to the planning committee by May 31, 2021. Presenters’ registration fees will be covered after acceptance. 

--- a/content/sponsors/_index.md
+++ b/content/sponsors/_index.md
@@ -1,5 +1,4 @@
 ---
-title: "Sponsors"
+title: "Sponsors from previous years"
 description: "Cascadia R Conf Sponsors"
 ---
-

--- a/content/venue-2020.html
+++ b/content/venue-2020.html
@@ -1,0 +1,82 @@
++++
+title = "Venue"
++++
+
+<style>
+
+a:hover {
+  text-decoration: none;
+  color: #EA33E4;
+}
+
+#location a {
+  color: #036936;
+}
+#location a:hover {
+  color: #FEE11A;
+}
+body {
+  font-size: 1.7em;
+  font-weight: normal; 
+}
+</style>
+
+
+<div class="center" id="location" style="text-align: center">
+  <h1>Location</h1>
+  <h3><a href = "https://emu.uoregon.edu"> Erb Memorial Union (EMU), University of Oregon</a></h3>
+  <h3>1395 University St, Eugene, OR 97403</h3>
+</div>
+
+Keynotes and other conference events involving all attendees will take place in the <a href = "https://emu.uoregon.edu/map?location=RedwoodAuditorium"> Redwood Auditorium </a> on the second floor of the EMU. Training sessions will be held in the Crater Lake <a href = "https://emu.uoregon.edu/map?location=CraterLakeNorthRoom"> North </a> and <a href = "https://emu.uoregon.edu/map?location=CraterLakeSouthRoom"> South </a> rooms on the first floor.
+
+
+
+<h2> Parking </h2>
+Parking in most University of Oregon parking lots will be free for the day of the conference (given it's a Sunday). Please see the PDF map <a href = "https://business.uoregon.edu/sites/business1.uoregon.edu/files/media/campus-parking-map.pdf"> here </a> for a list of parking lots and their relation to the EMU. 
+
+Metered parking is also generally free on Sunday, and the spots on University Street near McArthur court would be a good spot to look first. Lots 18, 17, and 16A are good alternatives.
+
+<br/>
+<br/>
+
+
+<center>
+  <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2867.867278965272!2d-123.07581018475531!3d44.04479697910983!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x54c11e3bac2a3033%3A0x6a24a4c7afb332f7!2sErb%20Memorial%20Union!5e0!3m2!1sen!2sus!4v1581915340637!5m2!1sen!2sus" width="600" height="450" frameborder="0" style="border:0;" allowfullscreen=""></iframe>
+  </center>
+
+
+<!-- the actual map 
+  <div id='map' style='height: 500px;position: relative;margin: auto;'></div>
+  <br>
+  <p><strong>Directions:</strong> Please enter CLSB through the South entrance and go to the 3rd floor via the South Elevators. 3A001/3A002 (the main conference location) is across the short bridge.</p> 
+  <img src="../img/enter.png" width="300"> 
+  
+<script>
+    L.mapbox.accessToken = 'pk.eyJ1IjoicmVjb2xvZ3kiLCJhIjoiZWlta1B0WSJ9.u4w33vy6kkbvmPyGnObw7A';
+      var map = L.mapbox.map("map", "mapbox.streets")
+      .setView([44.048, -123.06], 14);
+
+    var geojson = [
+      {
+        type: "Feature",
+          "geometry": { "type": "Point", "coordinates": [ -123.074570, 44.043861 ]},
+          "properties": {
+              "place": "Erb Memorial Union",
+              "marker-symbol": "circle",
+              "marker-color": "#036936",
+              // "nosoy": false,
+              // "url": "https://emu.uoregon.edu",
+              "menu": "null",
+              "notes": "null"
+          }
+      }
+    ];
+
+    var markers = L.mapbox.featureLayer()
+      .setGeoJSON(geojson)
+      .addTo(map);
+  </script>
+</div> -->
+
+<br><br><br>

--- a/content/venue.html
+++ b/content/venue.html
@@ -24,59 +24,8 @@ body {
 
 <div class="center" id="location" style="text-align: center">
   <h1>Location</h1>
-  <h3><a href = "https://emu.uoregon.edu"> Erb Memorial Union (EMU), University of Oregon</a></h3>
-  <h3>1395 University St, Eugene, OR 97403</h3>
+  <h3>Cascadia R Conference 2021 will be held virtually.</h3>
+  <h3>Platform details will be available in May.</h3>
 </div>
-
-Keynotes and other conference events involving all attendees will take place in the <a href = "https://emu.uoregon.edu/map?location=RedwoodAuditorium"> Redwood Auditorium </a> on the second floor of the EMU. Training sessions will be held in the Crater Lake <a href = "https://emu.uoregon.edu/map?location=CraterLakeNorthRoom"> North </a> and <a href = "https://emu.uoregon.edu/map?location=CraterLakeSouthRoom"> South </a> rooms on the first floor.
-
-
-
-<h2> Parking </h2>
-Parking in most University of Oregon parking lots will be free for the day of the conference (given it's a Sunday). Please see the PDF map <a href = "https://business.uoregon.edu/sites/business1.uoregon.edu/files/media/campus-parking-map.pdf"> here </a> for a list of parking lots and their relation to the EMU. 
-
-Metered parking is also generally free on Sunday, and the spots on University Street near McArthur court would be a good spot to look first. Lots 18, 17, and 16A are good alternatives.
-
-<br/>
-<br/>
-
-
-<center>
-  <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2867.867278965272!2d-123.07581018475531!3d44.04479697910983!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x54c11e3bac2a3033%3A0x6a24a4c7afb332f7!2sErb%20Memorial%20Union!5e0!3m2!1sen!2sus!4v1581915340637!5m2!1sen!2sus" width="600" height="450" frameborder="0" style="border:0;" allowfullscreen=""></iframe>
-  </center>
-
-
-<!-- the actual map 
-  <div id='map' style='height: 500px;position: relative;margin: auto;'></div>
-  <br>
-  <p><strong>Directions:</strong> Please enter CLSB through the South entrance and go to the 3rd floor via the South Elevators. 3A001/3A002 (the main conference location) is across the short bridge.</p> 
-  <img src="../img/enter.png" width="300"> 
-  
-<script>
-    L.mapbox.accessToken = 'pk.eyJ1IjoicmVjb2xvZ3kiLCJhIjoiZWlta1B0WSJ9.u4w33vy6kkbvmPyGnObw7A';
-      var map = L.mapbox.map("map", "mapbox.streets")
-      .setView([44.048, -123.06], 14);
-
-    var geojson = [
-      {
-        type: "Feature",
-          "geometry": { "type": "Point", "coordinates": [ -123.074570, 44.043861 ]},
-          "properties": {
-              "place": "Erb Memorial Union",
-              "marker-symbol": "circle",
-              "marker-color": "#036936",
-              // "nosoy": false,
-              // "url": "https://emu.uoregon.edu",
-              "menu": "null",
-              "notes": "null"
-          }
-      }
-    ];
-
-    var markers = L.mapbox.featureLayer()
-      .setGeoJSON(geojson)
-      .addTo(map);
-  </script>
-</div> -->
 
 <br><br><br>

--- a/content/years.html
+++ b/content/years.html
@@ -2,6 +2,20 @@
 url = "/years"
 +++
 
+<h2>2021</h2>
+
+<ul>
+    <li><h2>Virtual</h2></li>
+</ul>
+
+
+<h2>2020</h2>
+
+<ul>
+    <li><h2>Cancelled</h2></li>
+</ul>
+
+
 <h2>2019</h2>
 
 <ul>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -15,7 +15,7 @@
 
         </header>
         
-        {{ partial "alert.html" . }}
+        <!--{{ partial "alert.html" . }}-->
 
         {{ partial "carousel.html" . }}
         

--- a/layouts/partials/sticker.html
+++ b/layouts/partials/sticker.html
@@ -2,6 +2,6 @@
     <div class="container">
       <h1 style="text-align: center">CascadiaRConf</h1>
       <p style="text-align: center"><img src="../{{ .Site.Params.logo_sticker }}" width="300" title="Remember to get your sticker at the conference"></img></p>
-      <h3 style="text-align: center">May 31st, 2020 <br><br>Eugene, OR</h3>
+      <h3 style="text-align: center">June 4-5, 2021<br><br>Virtual conference</h3>
     </div>
 </section>


### PR DESCRIPTION
CFP appears on "speakers" page (killing two birds with one stone, publishing CFP and removing info from 2020). Box on front page links to CFP, from which the submission form can be found.

I rendered locally and it appeared OK, but could use another set of eyes before going live (or at least before starting to advertise CFP). 

Additional issues that should be addressed eventually described in #50 

@thebioengineer , here ya go!